### PR TITLE
Initialize Node test framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,3 +166,12 @@ Meaning is an Identity that arises from Realizing Value
 ### Subjects
 
 A Subject is a Runtime Construct that has Identities and Values within a Frame.
+
+## Running tests
+
+After building the TypeScript sources, run the test suite with Node:
+
+```bash
+yarn build && node --test test
+```
+

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "watch": "tsc -w",
     "lint": "eslint src",
     "prelint:write": "yarn -s lint -f json > status/eslint-results.json; exit 0",
-    "lint:write": "yarn -s eslint --fix --plugin eslint-plugin-json-format status/*.json"
+    "lint:write": "yarn -s eslint --fix --plugin eslint-plugin-json-format status/*.json",
+    "test": "yarn build && node --test test"
   },
   "repository": {
     "type": "git",

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -1,0 +1,13 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { parse } from '../public/js/parser/parse.mjs';
+
+test('parses numeric token', () => {
+  const token = parse('2', { asGenerator: false });
+  assert.equal(token.kind, 'numeric');
+});
+
+test('parses phrasal token', () => {
+  const token = parse('2 2', { asGenerator: false });
+  assert.equal(token.kind, 'phrasal');
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,5 +18,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true
-  }
+  },
+  "include": [
+    "src/**/*"
+  ]
 }


### PR DESCRIPTION
## Summary
- set up Node.js tests using built-in test runner
- add basic parsing tests
- add section in README on running the tests
- limit TypeScript compilation to src folder

## Testing
- `yarn build && node --test test`


------
https://chatgpt.com/codex/tasks/task_b_685f5c3061cc832a8d4a43751fcfaf44