### PR TITLE
Refactor generator flow

### DIFF
--- a/src/core/node/cursor.mts
+++ b/src/core/node/cursor.mts
@@ -41,10 +41,9 @@ export class Cursor {
     const generators = generatorArray ?? this.generators;
     if (!generators) throw new Error('Cannot scan without generators');
 
-
     let activeCursor = former;
     for (const generator of generators) {
-      const cursor = yield* generator(this, activeCursor);
+      const cursor = yield* generator({start: this, prev: activeCursor});
       const token  = cursor ? cursor.getToken() : false;
 
       if (!token) continue;

--- a/src/parser/constructs/constructs.mts
+++ b/src/parser/constructs/constructs.mts
@@ -8,7 +8,12 @@ import {container} from './nodal/container/generator.mjs';
 import {literal} from './nodal/literal/generator.mjs';
 import {Cursor} from '../../core/node/cursor.mjs';
 
-export type ConstructGenerator = (start: Cursor, prev: Cursor) => Generator;
+export interface GeneratorArgs {
+  start: Cursor;
+  prev?: Cursor;
+}
+
+export type ConstructGenerator = (args: GeneratorArgs) => Generator;
 
 type ConstructGeneratorObj = { [key: string]: ConstructGenerator };
 

--- a/src/parser/constructs/nodal/container/generator.mts
+++ b/src/parser/constructs/nodal/container/generator.mts
@@ -3,8 +3,9 @@ import {takeSpaces} from '../../operational/semantic/phrasal/cursor/motions/take
 import {_operator} from '../../operational/generator.builder.mjs';
 import {containerPartOptions} from './parts/parts.mjs';
 import {containerDelimitingOperators} from './parts/operators.mjs';
+import type {GeneratorArgs} from '../../constructs.mjs';
 
-export function* container(start, prev) {
+export function* container({start, prev}: GeneratorArgs) {
   const cursor = start.spawn(prev);
 
   cursor.token({kind: 'container'});

--- a/src/parser/constructs/nodal/literal/generator.mts
+++ b/src/parser/constructs/nodal/literal/generator.mts
@@ -3,8 +3,9 @@ import {takeSpaces} from '../../operational/semantic/phrasal/cursor/motions/take
 import {_operator} from '../../operational/generator.builder.mjs';
 import {literalPartOptions} from './parts/parts.mjs';
 import {literalDelimitingOperators} from './parts/operators.mjs';
+import type {GeneratorArgs} from '../../constructs.mjs';
 
-export function* literal(start, prev) {
+export function* literal({start, prev}: GeneratorArgs) {
   const cursor = start.spawn(prev);
 
   cursor.token({kind: 'literal'});

--- a/src/parser/constructs/nodal/literal/parts/anything/generator.mts
+++ b/src/parser/constructs/nodal/literal/parts/anything/generator.mts
@@ -1,7 +1,8 @@
 import {beginsAnything} from './cursor/beginsAnything.mjs';
 import {continuesAnything} from './cursor/continuesAnything.mjs';
+import type {GeneratorArgs} from '../../../../constructs.mjs';
 
-export function* anything(start, prev) {
+export function* anything({start, prev}: GeneratorArgs) {
   const cursor = start.spawn(prev);
 
   cursor.token({kind: 'anything'});

--- a/src/parser/constructs/nodal/nominal/generator.mts
+++ b/src/parser/constructs/nodal/nominal/generator.mts
@@ -1,9 +1,10 @@
 import {beginsNominal} from './cursor/beginsNominal.mjs';
 import {continuesNominal} from './cursor/continuesNominal.mjs';
 import {takeDefinition} from './parts/definition.mjs';
+import type {GeneratorArgs} from '../../constructs.mjs';
 
 
-export function* nominal(start, prev) {
+export function* nominal({start, prev}: GeneratorArgs) {
   const cursor = start.spawn(prev);
 
   cursor.token({kind: 'nominal'});

--- a/src/parser/constructs/nodal/numeric/generator.mts
+++ b/src/parser/constructs/nodal/numeric/generator.mts
@@ -1,7 +1,8 @@
 import {beginsNumeric} from './cursor/beginsNumeric.mjs';
 import {continuesNumeric} from './cursor/continuesNumeric.mjs';
+import type {GeneratorArgs} from '../../constructs.mjs';
 
-export function* numeric(start, prev) {
+export function* numeric({start, prev}: GeneratorArgs) {
   const cursor = start.spawn(prev);
   cursor.token({kind: 'numeric'});
 

--- a/src/parser/constructs/operational/generator.builder.mts
+++ b/src/parser/constructs/operational/generator.builder.mts
@@ -2,8 +2,8 @@ import {takeOperator} from "./pragmatic/cursor/takeOperator.mjs";
 import {takeLabel}    from "./pragmatic/cursor/motions/takeLabel.mjs";
 
 export function _operator(operators) {
-  return function* (startingCursor) {
-    const cursor = startingCursor.spawn();
+  return function* ({start}) {
+    const cursor = start.spawn();
 
     cursor.token({kind: 'operator'});
 
@@ -21,8 +21,8 @@ export function _operator(operators) {
       yield* cursor.log({
                           message: 'not an operator',
                           miss:    'no prototype',
-                          cursors: {start: startingCursor},
-                          info:    {operators, curr: startingCursor.curr()}
+                          cursors: {start},
+                          info:    {operators, curr: start.curr()}
                         });
       return false;
     }

--- a/src/parser/constructs/operational/pragmatic/generator.mts
+++ b/src/parser/constructs/operational/pragmatic/generator.mts
@@ -2,8 +2,9 @@ import {operationalPartOptions} from './parts/parts.mjs';
 import {takeSpaces} from '../semantic/phrasal/cursor/motions/takeSpaces.mjs';
 import {pragmaticOperators} from './parts/operators.mjs';
 import {_operator} from '../generator.builder.mjs';
+import type {GeneratorArgs} from '../../constructs.mjs';
 
-export function* operational(start, prev, domain = pragmaticOperators) {
+export function* operational({start, prev, domain = pragmaticOperators}: GeneratorArgs & {domain?: any}) {
   const cursor = start.spawn(prev);
   cursor.token({kind: 'operational'});
 

--- a/src/parser/constructs/operational/semantic/common/generator.mts
+++ b/src/parser/constructs/operational/semantic/common/generator.mts
@@ -3,8 +3,9 @@ import {commonPartOptions} from './parts/parts.mjs';
 import {takeSpaces} from '../phrasal/cursor/motions/takeSpaces.mjs';
 import {_operator} from '../../generator.builder.mjs';
 import {commonDelimitingOperators} from '../operators.mjs';
+import type {GeneratorArgs} from '../../../constructs.mjs';
 
-export function* common(start, prev) {
+export function* common({start, prev}: GeneratorArgs) {
   const cursor = start.spawn(prev);
   cursor.token({kind: 'common'});
 

--- a/src/parser/constructs/operational/semantic/ordinal/generator.mts
+++ b/src/parser/constructs/operational/semantic/ordinal/generator.mts
@@ -3,8 +3,9 @@ import {ordinalPartOptions} from './parts/parts.mjs';
 import {takeSpaces} from '../phrasal/cursor/motions/takeSpaces.mjs';
 import {_operator} from '../../generator.builder.mjs';
 import {ordinalDelimitingOperators} from '../operators.mjs';
+import type {GeneratorArgs} from '../../../constructs.mjs';
 
-export function* ordinal(start, prev) {
+export function* ordinal({start, prev}: GeneratorArgs) {
   const cursor = start.spawn(prev);
   cursor.token({kind: 'ordinal'});
 

--- a/src/parser/constructs/operational/semantic/phrasal/generator.mts
+++ b/src/parser/constructs/operational/semantic/phrasal/generator.mts
@@ -1,8 +1,9 @@
 import {isPhrasalDelimiter} from './cursor/checks/isPhrasalDelimiter.mjs';
 import {phrasalPartOptions} from './parts/parts.mjs';
 import {takeSpaces} from './cursor/motions/takeSpaces.mjs';
+import type {GeneratorArgs} from '../../../constructs.mjs';
 
-export function* phrasal(start, prev) {
+export function* phrasal({start, prev}: GeneratorArgs) {
   const cursor = start.spawn(prev);
   cursor.token({kind: 'phrasal'});
 


### PR DESCRIPTION
## Summary
- start normalizing generator API
- update cursor scan to use new args
- refactor operator builder
- adjust imports

## Testing
- `npm run build`
- `node public/js/parser/tests/test.mjs`

------
https://chatgpt.com/codex/tasks/task_b_685f659f9dc8832aa23555caf2e8759f