### PR TITLE
Add demo script tokens to parser tests

### DIFF
--- a/src/parser/tests/node-stubs.d.ts
+++ b/src/parser/tests/node-stubs.d.ts
@@ -1,0 +1,9 @@
+declare module 'node:test' {
+  const test: any;
+  export default test;
+}
+
+declare module 'node:assert/strict' {
+  const assert: any;
+  export default assert;
+}

--- a/src/parser/tests/test.mts
+++ b/src/parser/tests/test.mts
@@ -1,18 +1,87 @@
-import {parse} from '../parse.mjs';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { parse } from '../parse.mjs';
 
-let out: any =
-      Object.entries({
-                       '--false':       [' '],
-                       '--nominal':     ['one', 'one<two>', 'one<two>(three)', 'one(two)', 'one(two){three}', 'one{two}', 'one(two){three}[four]', 'one{two}[three]', 'one[two]'],
-                       '--literal':     ['`one`', '"one"'],
-                       '--numeric':     ['2', '2.2'],
-                       '--phrasal':     ['2 2', 'one two', 'one 2 three', 'onw two three', '{_one two }_three four'],
-                       '--common':      ['one two, three'],
-                       '--ordinal':     ['one two, three; four five', `\n      one\n      two \n      three\n      `, `\n      one;\n      two;\n      three;\n      `, `\n      one;\n      *_two;\n      three;\n      `],
-                       '--container':   ['{one}', '{ something }', '{_one two }_three'],
-                       '--operational': ['one*two', '*_one', 'one *two', 'one* two', 'one * two', 'one *_two three ', 'one@two', 'one * two@three'],
-                     });
+const cases: [string, string | false][] = [
+  [' ', false],
 
-out = Object.fromEntries(out.map(([k, v]) => [k, v.map(str => parse(str, {asGenerator: false})?.kind ?? str)]));
-out = JSON.parse(JSON.stringify(out));
-console.log(out);
+  // nominal examples
+  ['one', 'nominal'],
+  ['one<two>', 'nominal'],
+  ['one<two>(three)', 'nominal'],
+  ['one(two)', 'nominal'],
+  ['one(two){three}', 'nominal'],
+  ['one{two}', 'nominal'],
+  ['one(two){three}[four]', 'nominal'],
+  ['one{two}[three]', 'nominal'],
+  ['one[two]', 'nominal'],
+
+  // literal examples
+  ['`one`', 'literal'],
+  ['"one"', 'literal'],
+
+  // numeric examples
+  ['2', 'numeric'],
+  ['2.2', 'numeric'],
+
+  // phrasal examples
+  ['2 2', 'phrasal'],
+  ['one two', 'phrasal'],
+  ['one 2 three', 'phrasal'],
+  ['onw two three', 'phrasal'],
+  ['{_one two }_three four', 'phrasal'],
+
+  // common examples
+  ['one two, three', 'common'],
+
+  // ordinal examples
+  ['one two, three; four five', 'ordinal'],
+  [`\n      one\n      two \n      three\n      `, 'ordinal'],
+  [`\n      one;\n      two;\n      three;\n      `, 'ordinal'],
+  [`\n      one;\n      *_two;\n      three;\n      `, 'ordinal'],
+
+  // container examples
+  ['{one}', 'container structural'],
+  ['{ something }', 'container structural'],
+  ['{_one two }_three', 'container structural'],
+
+  // operational examples
+  ['one*two', 'operational pragmatic salience'],
+  ['*_one', 'operational pragmatic salience conceptual'],
+  ['one *two', 'operational pragmatic salience'],
+  ['one* two', 'operational pragmatic salience'],
+  ['one * two', 'operational pragmatic salience'],
+  ['one *_two three ', 'operational pragmatic salience'],
+  ['one@two', 'operational pragmatic perspective'],
+  ['one * two@three', 'operational pragmatic salience'],
+];
+
+// examples from demo.spw
+cases.push(
+  ['Metric', 'nominal'],
+  ['Command', 'nominal'],
+  ['metric_bus', 'nominal'],
+  ['command_bus', 'nominal'],
+  ['log_bus', 'nominal'],
+  ['bootstrap', 'nominal'],
+  ['ticker', 'nominal'],
+  ['echo', 'nominal'],
+  ['log("\ud83c\udfc1 bootstrapping…")', 'nominal'],
+  ['now()', 'nominal'],
+  ['sleep_ms(*TICK_MS)', 'nominal'],
+  ['<chan[Metric]>', 'container conceptual'],
+  ['@view', 'operational pragmatic perspective'],
+  ['"\ud83c\udf33 Playground active — press Ctrl-C to quit\\n"', 'literal'],
+);
+
+for (const [input, expected] of cases) {
+  test(`${JSON.stringify(input)} -> ${expected}`, () => {
+    const result = parse(input, { asGenerator: false });
+    if (expected === false) {
+      assert.equal(result, false);
+    } else {
+      assert.ok(result);
+      assert.equal(result.kind, expected);
+    }
+  });
+}

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -11,3 +11,18 @@ test('parses phrasal token', () => {
   const token = parse('2 2', { asGenerator: false });
   assert.equal(token.kind, 'phrasal');
 });
+
+test('parses token from demo script', () => {
+  const token = parse('log("\ud83c\udfc1 bootstrapping…")', { asGenerator: false });
+  assert.equal(token.kind, 'nominal');
+});
+
+test('parses demo container token', () => {
+  const token = parse('<chan[Metric]>', { asGenerator: false });
+  assert.equal(token.kind, 'container conceptual');
+});
+
+test('parses demo operational token', () => {
+  const token = parse('@view', { asGenerator: false });
+  assert.equal(token.kind, 'operational pragmatic perspective');
+});


### PR DESCRIPTION
## Summary
- expand parser tests using tokens from demo.spw
- exercise parser on demo constructs like containers and operational forms

## Testing
- `npm run build`
- `node public/js/parser/tests/test.mjs`
- `node --test test`


------
https://chatgpt.com/codex/tasks/task_b_685f634c5e50832ab7cfd94086f0630e