### PR TITLE
Add runtime generator stubs

### DIFF
--- a/spw-language/packages/spw-runtime/src/channel.ts
+++ b/spw-language/packages/spw-runtime/src/channel.ts
@@ -1,0 +1,30 @@
+// src/channel.ts
+import { Instrument } from './instrument.js';
+
+export class Channel<T> {
+  #buffer: T[] = [];
+  constructor(
+    public readonly name: string,
+    private readonly size = 0,
+    private readonly instr: Instrument = { trace(){}, count(){} }
+  ) {}
+
+  send(value: T): void {
+    if (this.size && this.#buffer.length >= this.size) {
+      throw new Error(`Channel ${this.name} is full`);
+    }
+    this.#buffer.push(value);
+    this.instr.count(`channel.${this.name}.send`);
+    this.instr.trace('chan.send', { name: this.name, value });
+  }
+
+  *receive(): Generator<T, T, void> {
+    while (this.#buffer.length === 0) {
+      yield;                     // cooperate with scheduler
+    }
+    this.instr.count(`channel.${this.name}.recv`);
+    const v = this.#buffer.shift() as T;
+    this.instr.trace('chan.recv', { name: this.name, value: v });
+    return v;
+  }
+}

--- a/spw-language/packages/spw-runtime/src/chem.ts
+++ b/spw-language/packages/spw-runtime/src/chem.ts
@@ -1,0 +1,5 @@
+// src/chem.ts
+export function react(equation: string): string {
+  // TODO: real parsing/balancing
+  return `🔬 reaction(${equation})`;
+}

--- a/spw-language/packages/spw-runtime/src/cognitive.ts
+++ b/spw-language/packages/spw-runtime/src/cognitive.ts
@@ -1,0 +1,4 @@
+// src/cognitive.ts
+export function fittsLaw(distance: number, width: number): number {
+  return Math.log2(distance / width + 1);  // ID, not duration
+}

--- a/spw-language/packages/spw-runtime/src/context.ts
+++ b/spw-language/packages/spw-runtime/src/context.ts
@@ -1,0 +1,22 @@
+// src/context.ts
+import { Instrument } from './instrument.js';
+
+export interface ExecutionContext {
+  readonly instrument: Instrument;
+  constants: Map<string, unknown>;
+  channels: Map<string, Channel<unknown>>;
+  types: Map<string, unknown>;           // place-holder for type metadata
+}
+
+import type { Channel } from './channel.js';
+
+export function createContext(
+  instrument: Instrument
+): ExecutionContext {
+  return {
+    instrument,
+    constants: new Map(),
+    channels:  new Map(),
+    types:     new Map(),
+  };
+}

--- a/spw-language/packages/spw-runtime/src/error.ts
+++ b/spw-language/packages/spw-runtime/src/error.ts
@@ -1,0 +1,14 @@
+// src/error.ts
+import { Instrument } from './instrument.js';
+
+export function* tryCatch<T>(
+  tryBlock: () => Generator<unknown, T, unknown>,
+  catchBlock: (e: unknown) => Generator
+): Generator<unknown, T, unknown> {
+  try {
+    return yield* tryBlock();
+  } catch (e) {
+    yield* catchBlock(e);
+    throw e;
+  }
+}

--- a/spw-language/packages/spw-runtime/src/ffi.ts
+++ b/spw-language/packages/spw-runtime/src/ffi.ts
@@ -1,0 +1,20 @@
+// src/ffi.ts
+import { Instrument } from './instrument.js';
+
+export type FfiFn = (...args: unknown[]) => unknown;
+
+export class Ffi {
+  #symbols = new Map<string, FfiFn>();
+  constructor(private readonly instr: Instrument) {}
+
+  register(name: string, fn: FfiFn) {
+    this.#symbols.set(name, fn);
+    this.instr.trace('ffi.register', { name });
+  }
+  invoke<T>(name: string, ...args: unknown[]): T {
+    const fn = this.#symbols.get(name);
+    if (!fn) throw new Error(`ffi symbol ${name} missing`);
+    this.instr.count(`ffi.${name}.calls`);
+    return fn(...args) as T;
+  }
+}

--- a/spw-language/packages/spw-runtime/src/fiber.ts
+++ b/spw-language/packages/spw-runtime/src/fiber.ts
@@ -1,0 +1,45 @@
+// src/fiber.ts
+import { Instrument } from './instrument.js';
+
+export type FiberGen = Generator<unknown, unknown, unknown>;
+
+export enum FiberState { NEW, RUNNING, SUSPENDED, DONE, ERROR }
+
+export class Fiber {
+  state = FiberState.NEW;
+  error: unknown = null;
+
+  constructor(
+    public readonly name: string,
+    private readonly genFactory: () => FiberGen,
+    private readonly instr: Instrument = { trace(){}, count(){} }
+  ) {}
+
+  #gen: FiberGen | null = null;
+
+  /** step the fiber once; returns true if still runnable */
+  step(): boolean {
+    if (this.state === FiberState.NEW) {
+      this.#gen = this.genFactory();
+      this.state = FiberState.RUNNING;
+      this.instr.trace('fiber.start', { name: this.name });
+    }
+    if (!this.#gen) return false;
+
+    try {
+      const res = this.#gen.next();
+      if (res.done) {
+        this.state = FiberState.DONE;
+        this.instr.trace('fiber.done', { name: this.name });
+        return false;
+      }
+      this.state = FiberState.SUSPENDED;
+      return true;
+    } catch (e) {
+      this.state = FiberState.ERROR;
+      this.error = e;
+      this.instr.trace('fiber.error', { name: this.name, error: String(e) });
+      return false;
+    }
+  }
+}

--- a/spw-language/packages/spw-runtime/src/graft.ts
+++ b/spw-language/packages/spw-runtime/src/graft.ts
@@ -1,0 +1,30 @@
+// src/graft.ts
+import { Instrument } from './instrument.js';
+import type { Fiber } from './fiber.js';
+
+export interface Patch {
+  targetFlow: string;
+  newFactory: () => Generator;
+}
+
+export class GraftManager {
+  #patches: Patch[] = [];
+  constructor(private readonly instr: Instrument) {}
+
+  queue(patch: Patch) {
+    this.#patches.push(patch);
+    this.instr.trace('graft.patchQueued', { target: patch.targetFlow });
+  }
+  apply(fibers: Map<string, Fiber>) {
+    for (const p of this.#patches.splice(0)) {
+      const fiber = fibers.get(p.targetFlow);
+      if (fiber) {
+        fibers.set(
+          p.targetFlow,
+          new Fiber(p.targetFlow, p.newFactory, this.instr)
+        );
+        this.instr.trace('graft.applied', { target: p.targetFlow });
+      }
+    }
+  }
+}

--- a/spw-language/packages/spw-runtime/src/index.ts
+++ b/spw-language/packages/spw-runtime/src/index.ts
@@ -1,0 +1,30 @@
+// src/index.ts
+import { createContext } from './context.js';
+import { Scheduler } from './scheduler.js';
+import { Fiber } from './fiber.js';
+import { createLoggerFiber } from './logger.js';
+import { Channel } from './channel.js';
+import { NullInstrument } from './instrument.js';
+
+// Boot sequence for a tiny “hello runtime” test
+const instr = NullInstrument;                    // plug in Datadog etc.
+const ctx = createContext(instr);
+const sched = new Scheduler(instr);
+
+// Example: user log channel and fiber
+const logChan = new Channel<string>('log', 0, instr);
+ctx.channels.set('log', logChan);
+sched.spawn(createLoggerFiber('logger', logChan, instr));
+
+// Example worker fiber
+sched.spawn(
+  new Fiber('worker', function* () {
+    logChan.send('[boot] worker online');
+    yield* sleepMs(250);
+    logChan.send('[done] worker exiting');
+  }, instr)
+);
+
+// Start the show
+import { sleepMs } from './timer.js';
+sched.run();

--- a/spw-language/packages/spw-runtime/src/instrument.ts
+++ b/spw-language/packages/spw-runtime/src/instrument.ts
@@ -1,0 +1,10 @@
+// src/instrument.ts
+export interface Instrument {
+  trace(event: string, data?: Record<string, unknown>): void;
+  count(metric: string, delta?: number): void;
+}
+
+export const NullInstrument: Instrument = {
+  trace: () => {},
+  count: () => {},
+};

--- a/spw-language/packages/spw-runtime/src/io.ts
+++ b/spw-language/packages/spw-runtime/src/io.ts
@@ -1,0 +1,13 @@
+// src/io.ts
+import readline from 'node:readline/promises';
+import { stdin as input, stdout as output } from 'node:process';
+
+const rl = readline.createInterface({ input, output });
+
+export async function inputPrompt(prompt: string): Promise<string> {
+  return rl.question(prompt);
+}
+
+export function outputLine(text: string): void {
+  console.log(text);
+}

--- a/spw-language/packages/spw-runtime/src/logger.ts
+++ b/spw-language/packages/spw-runtime/src/logger.ts
@@ -1,0 +1,19 @@
+// src/logger.ts
+import { Channel } from './channel.js';
+import { Instrument } from './instrument.js';
+import { Fiber } from './fiber.js';
+
+export function createLoggerFiber(
+  name: string,
+  chan: Channel<string>,
+  instr: Instrument
+): Fiber {
+  function* run() {
+    while (true) {
+      const line: string = yield* chan.receive();
+      console.log(line);
+      instr.trace('logger.out', { line });
+    }
+  }
+  return new Fiber(name, run, instr);
+}

--- a/spw-language/packages/spw-runtime/src/scheduler.ts
+++ b/spw-language/packages/spw-runtime/src/scheduler.ts
@@ -1,0 +1,24 @@
+// src/scheduler.ts
+import { Fiber } from './fiber.js';
+import { Instrument } from './instrument.js';
+
+export class Scheduler {
+  #queue: Fiber[] = [];
+
+  constructor(private readonly instr: Instrument = { trace(){}, count(){} }) {}
+
+  spawn(f: Fiber) {
+    this.#queue.push(f);
+    this.instr.trace('sched.spawn', { fiber: f.name });
+  }
+
+  run(): void {
+    while (this.#queue.length) {
+      const f = this.#queue.shift()!;
+      const alive = f.step();
+      if (alive && f.state !== 4) { // not DONE/ERROR
+        this.#queue.push(f);
+      }
+    }
+  }
+}

--- a/spw-language/packages/spw-runtime/src/statechart.ts
+++ b/spw-language/packages/spw-runtime/src/statechart.ts
@@ -1,0 +1,22 @@
+// src/statechart.ts
+import { Instrument } from './instrument.js';
+
+export interface Transition { event: string; to: string; }
+
+export class Statechart {
+  #state: string;
+  constructor(
+    start: string,
+    private readonly graph: Map<string, Transition[]>,
+    private readonly instr: Instrument
+  ) { this.#state = start; }
+
+  event(e: string) {
+    const trans = this.graph.get(this.#state)?.find(t => t.event === e);
+    if (trans) {
+      this.instr.trace('statechart.transition', { from: this.#state, to: trans.to, event: e });
+      this.#state = trans.to;
+    }
+  }
+  get state() { return this.#state; }
+}

--- a/spw-language/packages/spw-runtime/src/timer.ts
+++ b/spw-language/packages/spw-runtime/src/timer.ts
@@ -1,0 +1,7 @@
+// src/timer.ts
+export function* sleepMs(ms: number): Generator<void, void, void> {
+  const end = Date.now() + ms;
+  while (Date.now() < end) {
+    yield;      // cooperative wait
+  }
+}

--- a/spw-language/packages/spw-runtime/src/units.ts
+++ b/spw-language/packages/spw-runtime/src/units.ts
@@ -1,0 +1,5 @@
+// src/units.ts
+export function convert(value: number, from: string, to: string): number {
+  if (from === to) return value;
+  throw new Error(`unit conversion ${from}→${to} not implemented`);
+}


### PR DESCRIPTION
## Summary
- add a new runtime package skeleton under `spw-language/packages/spw-runtime`
- define instrumentation and context helpers
- implement basic fiber, scheduler, and channel primitives
- include utility modules like timers, graft manager and FFI
- provide a small demo in `index.ts`

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_b_685f6829d920832ab02be4506644b5bc