### PR TITLE
Add parser support for seed specification grammar

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lint": "eslint src",
     "prelint:write": "yarn -s lint -f json > status/eslint-results.json; exit 0",
     "lint:write": "yarn -s eslint --fix --plugin eslint-plugin-json-format status/*.json",
-    "test": "yarn build && node --test test"
+    "test": "yarn build && node --test \"test/**/*.js\""
   },
   "repository": {
     "type": "git",

--- a/src/parser/constructs/constructs.mts
+++ b/src/parser/constructs/constructs.mts
@@ -6,13 +6,14 @@ import {ordinal} from './operational/semantic/ordinal/generator.mjs';
 import {operational} from './operational/pragmatic/generator.mjs';
 import {container} from './nodal/container/generator.mjs';
 import {literal} from './nodal/literal/generator.mjs';
+import {comment} from './nodal/comment/generator.mjs';
 import {Cursor} from '../../core/node/cursor.mjs';
 
 export type ConstructGenerator = (start: Cursor, prev: Cursor) => Generator;
 
 type ConstructGeneratorObj = { [key: string]: ConstructGenerator };
 
-export const nodalConstructs: ConstructGeneratorObj     = {literal, container, nominal, numeric};
+export const nodalConstructs: ConstructGeneratorObj     = {literal, container, nominal, numeric, comment};
 export const pragmaticConstructs: ConstructGeneratorObj = {operational};
 export const semanticConstructs: ConstructGeneratorObj  = {phrasal, common, ordinal};
 

--- a/src/parser/constructs/nodal/comment/generator.mts
+++ b/src/parser/constructs/nodal/comment/generator.mts
@@ -1,0 +1,31 @@
+export function* comment(start, prev) {
+  const cursor = start.spawn(prev);
+
+  cursor.token({kind: 'comment'});
+
+  yield* cursor.log({message: 'checking comment'});
+
+  if (cursor.curr() !== '/' || cursor.input?.[cursor.offset + 1] !== '/') {
+    yield* cursor.log({
+                        message: 'not comment',
+                        miss:    'no comment prefix',
+                      });
+    cursor.token(false);
+    return prev ?? false;
+  }
+
+  yield* cursor.take();
+  yield* cursor.take();
+
+  const body: any[] = [];
+
+  while (cursor.curr() && cursor.curr() !== '\n' && cursor.curr() !== '\r') {
+    body.push({key: cursor.curr()});
+    yield* cursor.take();
+  }
+
+  cursor.token({head: {body: [{key: '/'}, {key: '/'}]}});
+  cursor.token({body});
+
+  return cursor;
+}

--- a/src/parser/constructs/nodal/container/cursor/beginsContainer.mts
+++ b/src/parser/constructs/nodal/container/cursor/beginsContainer.mts
@@ -9,5 +9,6 @@ import {containerDelimitingOperators} from "../parts/operators.mjs";
 export function beginsContainer(cursor) {
   const char = cursor.curr();
   if (!char) return false;
+  if (char === '<' && cursor.input?.[cursor.offset + 1] === '=') return false;
   return !!containerDelimitingOperators.open[char];
 }

--- a/src/parser/constructs/nodal/container/parts/parts.mts
+++ b/src/parser/constructs/nodal/container/parts/parts.mts
@@ -6,6 +6,7 @@ import {ordinal}     from "../../../operational/semantic/ordinal/generator.mjs";
 import {container}   from "../generator.mjs";
 import {operational} from "../../../operational/pragmatic/generator.mjs";
 import {literal}     from "../../literal/generator.mjs";
+import {comment}     from "../../comment/generator.mjs";
 
 export const containerPartOptions = [
   nominal,
@@ -15,5 +16,6 @@ export const containerPartOptions = [
   phrasal,
   common,
   ordinal,
-  operational
+  operational,
+  comment,
 ];

--- a/src/parser/constructs/nodal/nominal/cursor/beginsNominal.mts
+++ b/src/parser/constructs/nodal/nominal/cursor/beginsNominal.mts
@@ -1,4 +1,4 @@
 export function beginsNominal(char) {
   if (!char) return false;
-  return /[a-zA-Z]/.test(char);
+  return /\p{L}/u.test(char) || ['↘', '↗', '↙', '↖', '↔', '↕', '→', '←', '↑', '↓', '%', '␠'].includes(char);
 }

--- a/src/parser/constructs/nodal/nominal/cursor/continuesNominal.mts
+++ b/src/parser/constructs/nodal/nominal/cursor/continuesNominal.mts
@@ -2,5 +2,5 @@ import {beginsNominal} from "./beginsNominal.mjs";
 
 export function continuesNominal(char) {
   if (!char) return false;
-  return beginsNominal(char) || (char === '_');
+  return beginsNominal(char) || (char === '_') || /\d/.test(char);
 }

--- a/src/parser/constructs/nodal/nominal/generator.mts
+++ b/src/parser/constructs/nodal/nominal/generator.mts
@@ -28,6 +28,16 @@ export function* nominal(start, prev) {
     return false;
   }
 
+  if (/^\d+$/.test(key)) {
+    yield* cursor.log({
+                        message: 'not nominal',
+                        miss:    'numeric token',
+                      });
+    cursor.token(false);
+    cursor.offset = cursor.start;
+    return false;
+  }
+
   yield* cursor.log({message: 'resolving nominal'});
 
   const head = {key: key};

--- a/src/parser/constructs/operational/pragmatic/parts/operators.mts
+++ b/src/parser/constructs/operational/pragmatic/parts/operators.mts
@@ -6,15 +6,57 @@ export const pragmaticOperators =
                    kind:  'pragmatic',
                    kinds: new Set(['pragmatic', 'nominal']),
                  },
+                 '^': {
+                   name:  'meta',
+                   key:   '^',
+                   kind:  'pragmatic',
+                   kinds: new Set(['pragmatic', 'nominal']),
+                 },
+                 '#': {
+                   name:  'macro',
+                   key:   '#',
+                   kind:  'pragmatic',
+                   kinds: new Set(['pragmatic', 'nominal']),
+                 },
+                 '~': {
+                   name:  'style',
+                   key:   '~',
+                   kind:  'pragmatic',
+                   kinds: new Set(['pragmatic', 'nominal']),
+                 },
                  '@': {
                    name:  'perspective',
                    key:   '@',
                    kind:  'pragmatic',
                    kinds: new Set(['pragmatic', 'nominal']),
                  },
+                 '?': {
+                   name:  'query',
+                   key:   '?',
+                   kind:  'pragmatic',
+                   kinds: new Set(['pragmatic', 'nominal']),
+                 },
+                 '!': {
+                   name:  'accent',
+                   key:   '!',
+                   kind:  'pragmatic',
+                   kinds: new Set(['pragmatic', 'nominal']),
+                 },
+                 '\'': {
+                   name:  'hold',
+                   key:   '\'',
+                   kind:  'pragmatic',
+                   kinds: new Set(['pragmatic', 'nominal']),
+                 },
+                 '°': {
+                   name:  'snap',
+                   key:   '°',
+                   kind:  'pragmatic',
+                   kinds: new Set(['pragmatic', 'nominal']),
+                 },
                  ':': {
                    name:  'binding',
-                   key:   '@',
+                   key:   ':',
                    kind:  'pragmatic',
                    kinds: new Set(['pragmatic', 'nominal']),
                  },
@@ -29,8 +71,80 @@ export const pragmaticOperators =
                    key:   '-',
                    kind:  'pragmatic',
                    kinds: new Set(['pragmatic', 'nominal']),
+                   nodes: {
+                     '>': {
+                       name:  'flow',
+                       key:   '->',
+                       kind:  'pragmatic',
+                       kinds: new Set(['pragmatic', 'nominal']),
+                     }
+                   }
+                 },
+                 '<': {
+                   name:  'lessThan',
+                   key:   '<',
+                   kind:  'pragmatic',
+                   kinds: new Set(['pragmatic', 'nominal']),
+                   nodes: {
+                     '=': {
+                       name:  'lessThanOrEqual',
+                       key:   '<=',
+                       kind:  'pragmatic',
+                       kinds: new Set(['pragmatic', 'nominal']),
+                     }
+                   }
+                 },
+                 '>': {
+                   name:  'greaterThan',
+                   key:   '>',
+                   kind:  'pragmatic',
+                   kinds: new Set(['pragmatic', 'nominal']),
+                   nodes: {
+                     '=': {
+                       name:  'greaterThanOrEqual',
+                       key:   '>=',
+                       kind:  'pragmatic',
+                       kinds: new Set(['pragmatic', 'nominal']),
+                     }
+                   }
+                 },
+                 '&': {
+                   name:  'parallel',
+                   key:   '&',
+                   kind:  'pragmatic',
+                   kinds: new Set(['pragmatic', 'nominal']),
+                 },
+                 '|': {
+                   name:  'alternation',
+                   key:   '|',
+                   kind:  'pragmatic',
+                   kinds: new Set(['pragmatic', 'nominal']),
+                 },
+                 ';': {
+                   name:  'sequence',
+                   key:   ';',
+                   kind:  'pragmatic',
+                   kinds: new Set(['pragmatic', 'nominal']),
+                 },
+                 '.': {
+                   name:  'select',
+                   key:   '.',
+                   kind:  'pragmatic',
+                   kinds: new Set(['pragmatic', 'nominal']),
+                   nodes: {
+                     '.': {
+                       name:  'range',
+                       key:   '..',
+                       kind:  'pragmatic',
+                       kinds: new Set(['pragmatic', 'nominal']),
+                     }
+                   }
                  },
                  '=': {
+                   name:  'bind',
+                   key:   '=',
+                   kind:  'pragmatic',
+                   kinds: new Set(['pragmatic', 'nominal']),
                    nodes: {
                      '>': {
                        name:  'transformation',
@@ -39,6 +153,6 @@ export const pragmaticOperators =
                        kinds: new Set(['pragmatic', 'nominal']),
                      }
                    }
-                 }
+                 },
                };
 

--- a/src/parser/constructs/operational/semantic/phrasal/cursor/checks/isPhrasalDelimiter.mts
+++ b/src/parser/constructs/operational/semantic/phrasal/cursor/checks/isPhrasalDelimiter.mts
@@ -1,3 +1,5 @@
 export function isPhrasalDelimiter(cursor) {
-  return cursor.curr() === ' ';
+  const char = cursor.curr();
+  if (!char) return false;
+  return /\s/.test(char);
 }

--- a/test/fixtures/seed.spw
+++ b/test/fixtures/seed.spw
@@ -1,0 +1,145 @@
+^seed[Spw.Language v:2025.10]{
+  @meta{author:"spwashi", license:"MIT", desc:"Symbolic grammar for motion across perception; print + web + audit."}
+
+  #atoms[~ # . ? ! * & @ ^ () [] {} <> = => -> : ; | ']
+  #units[t Hz bpm deg nm px mm %]
+  #channels[c a h t]                // visual, audio, haptic, text
+  #dims[x:0..1 y:0..1 z:0..9 t:0..N]
+
+  #fixity[
+    90: () [] {} <>                ; // enclosure
+    80: .                          ; // select
+    70: postfix[? ! ' °]           ; // query, accent, hold, snap
+    60: prefix[~ @ ^ # *]          ; // style/io/meta/beat/macro
+    50: infix[-> => = :]           ; // flow, produce, bind, kv
+    40: join[& |]                  ; // parallel / alternation
+    30: sequence[; ␠]              ; // list / whitespace
+  ]
+
+  #types[
+    Scalar, Vec2, Rect, Quad, Path, Text, Bool,
+    ColorOKLCH{L C H a}, Freq{Hz duty wave φ}, Time{dur:t ease:?},
+    Intent{guide|signal|texture|delight}, Role, Layer, Beat
+  ]
+
+  #defaults[
+    units:px, fps:12, tempo:bpm96, easing:cubic,
+    contrast:AA, flicker_guard:<3Hz, salience_max:1.0
+  ]
+
+  #palette[
+    teal{L:0.72 C:0.16 H:190deg a:1},
+    yellow{L:0.82 C:0.14 H:95deg a:1},
+    cyan{L:0.78 C:0.18 H:210deg a:.95},
+    magenta{L:0.75 C:0.24 H:330deg a:1},
+    lime{L:0.78 C:0.19 H:135deg a:1},
+    bone{L:0.93 C:0.02 H:100deg a:1},
+    ink{L:0.20 C:0.04 H:200deg a:1}
+  ]
+
+  #style[
+    stroke{c:ColorOKLCH w:px cap:round join:round},
+    fill{c:ColorOKLCH}, blend{mode:normal|multiply|screen|overlay|add},
+    mask{id}, filter{blur:px glow:px}, opacity:%
+    // compact color & frequency shorthands
+    ~c{L C H a} ~λ{nm} ~f{Hz duty wave:sine|square|tri φ}
+  ]
+
+  #motion[
+    glide{to:Vec2 Time}, pulse{amp:% Time}, orbit{r:% Time},
+    path{d:Path Time}, scan{dir:↘ width:% Time}, draw{Time}, write{Time},
+    morph{from:id to:id Time}, oscillate{axis:x|y amp:% Time},
+    hold{dur:t}
+  ]
+
+  #intent[
+    guide{eye_path:↘ dwell:0.4t}, signal{prio:high},
+    texture{prio:low}, delight{micro:true}
+  ]
+
+  #budget[
+    per_beat{salience<=1.0 motion<=0.6 color<=0.3}  // compiler-enforced
+  ]
+
+  #a11y[
+    caption:on, alt:auto, aria:role, haptic{map:@event -> Freq},
+    audio{map:@event -> Freq}, color_safe:{contrast:AA}
+  ]
+
+  #print[
+    page{unit:mm size:[260,260] bleed:3 dpi:300},
+    inks[CMYK SPOT{NeonMagenta Teal}],
+    seps{ role:Ports -> SPOT.NeonMagenta knockout:true;
+          role:Beam  -> SPOT.Teal;
+          role:Anchors -> K:80 trap:0.15mm },
+    fluids{ Beam{flow:0.35 ~blend:multiply screen:roundDot@85lpi angle:15deg} }
+  ]
+
+  #hash[
+    canon{sortKeys:true numQuant:1e-3 color:oklch@2dp},
+    struct:=Merkle(BLAKE3(node.kind, attrs, children))->u256,
+    paint:=SimHash(strokeVectors)->u64,
+    text :=SHA256(normalizeText)->u256,
+    image:=pHash64(render@128px),
+    shingles:=Subtrees[size=3..7], sketch:=MinHash64(shingles),
+    match{Jaccard(sketch)>=0.72 or Hamming(image)<=8}
+  ]
+
+  #targets[ web{svg canvas lottie} procreate{animation_assist} ae midi haptics pdfx:4 ]
+  #export[ svg:true png_seq:true json:true captions:vtt hashes:true ]
+
+  // ---------- Scene schema ----------
+  #model[
+    Scene{id slug dims channels layers:[] beats:[] assets:{} data:{}},
+    Layer{id role intent:? geom:? style:? motion:? a11y:? bind:? z:?},
+    Beat{t actions:[cmd], budget:?}, cmd:=any
+  ]
+
+  // ---------- Example A: Diagonal Beam ----------
+  ^scene[diag_beam v:0.2]{
+    roles[Border TiltedFrame Beam Ports Anchors Blossoms]
+    layers[
+      Border{z:3 [rect{x:0.02,y:0.02,w:0.96,h:0.96}] ~c{L:.82 C:.14 H:95deg} stroke{w:34}},
+      TiltedFrame{z:2 [rect{x:0.11,y:0.13,w:0.78,h:0.72}] ~c{L:1 C:0 H:0deg} stroke{w:18} ^fix{camera}},
+      Beam{z:1 [quad{pts:[[0.10,0.18],[0.88,0.74]] width:0.10}] ~c{L:.78 C:.18 H:210deg a:.35}
+           scan{dir:↘ width:0.10 Time{dur:6t}}},
+      Ports{z:2 [round{x:0.82,y:0.34,w:0.10,h:0.12,r:0.12},
+                 round{x:0.80,y:0.78,w:0.10,h:0.12,r:0.12}]
+            stroke{~c{L:.75 C:.24 H:330deg} w:18} filter{glow:6} ~f{Hz:8 duty:0.25}},
+      Anchors{z:2 #marks{pos:[[0.28,0.30],[0.50,0.52],[0.60,0.16]]} ~c{L:.78 C:.19 H:135deg} },
+      Blossoms{z:0 [splotch{pos:[0.09,0.86] r:0.04}], ~c{L:.55 C:.20 H:20deg a:.65}}
+    ]
+    beats[
+      t0{TiltedFrame !enter; Beam hold{dur:0.2t}},
+      t1{Anchors pulse{amp:0.06 Time{dur:0.5t}}},
+      t2{Ports ~intent{signal}; @event{name:"gate-1"}},
+      t3{Beam scan{dir:↘ width:0.10 Time{dur:2t}}},
+      t4{!freeze; @export[svg png_seq captions hashes]}
+    ]
+  }
+
+  // ---------- Example B: Comb → Tray → Chute ----------
+  ^scene[comb_tray_chute v:0.3]{
+    roles[Border Frame Comb Tray Chute Gauge Drips]
+    layers[
+      Border{z:0 [rect{x:0.05,y:0.06,w:0.90,h:0.86}] stroke{~c{L:.82 C:.14 H:95deg} w:22}},
+      Frame {z:1 [rect{x:0.10,y:0.10,w:0.80,h:0.78}] stroke{~c{L:.72 C:.16 H:190deg} w:14}},
+      Comb  {z:2 @repeat teeth:9 within[x:0.16..0.42,y:0.16..0.20] [round{xw:0.024,yh:0.036,r:0.012}]
+                  stroke{~c{L:.75 C:.24 H:330deg} w:15} pulse{amp:0.008 Time{dur:0.5t}}},
+      Tray  {z:2 [rect{x:0.18,y:0.24,w:0.48,h:0.10,r:0.03}]
+                  stroke{~c{L:.72 C:.16 H:190deg} w:18} oscillate{axis:x amp:0.02 Time{dur:2t}}},
+      Chute {z:2 [quad{pts:[[0.55,0.26],[0.76,0.31],[0.66,0.58],[0.42,0.52]]}]
+                  stroke{~c{L:.72 C:.16 H:190deg} w:18} morph{} ^fix{parent}},
+      Gauge {z:3 [rect{x:0.56,y:0.34,w:0.06,h:0.22}] fill{~c{L:.82 C:.14 H:95deg a:.55}}
+                  [rect{x:0.585,y:0.36,w:0.02,h:0.18}] fill{~c{L:1 C:0 H:0deg}} pulse{amp:0.4 Time{dur:1t}}},
+      Drips {z:3 @spawn every:2t from:[0.50,0.66] shape:tri{w:0.02,h:0.024}
+                  ~c{L:.78 C:.18 H:210deg} path{d:↘ Time{dur:1.2t}} }
+    ]
+    beats[
+      t0{Frame !enter; Comb !on},
+      t1{Tray oscillate{axis:x amp:0.02 Time{dur:2t}}; Gauge !pulse},
+      t3{Drips @event{name:"drop"}},
+      t5{!freeze; @export[png_seq svg hashes]}
+    ]
+  }
+}

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -1,5 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
 import { parse } from '../public/js/parser/parse.mjs';
 
 test('parses numeric token', () => {
@@ -10,4 +11,11 @@ test('parses numeric token', () => {
 test('parses phrasal token', () => {
   const token = parse('2 2', { asGenerator: false });
   assert.equal(token.kind, 'phrasal');
+});
+
+test('parses seed specification', () => {
+  const fixture = fs.readFileSync(new URL('./fixtures/seed.spw', import.meta.url), 'utf8');
+  const token = parse(fixture, { asGenerator: false });
+  assert.ok(token);
+  assert.equal(token.kind, 'operational pragmatic meta');
 });


### PR DESCRIPTION
## Summary
- add a comment construct and broaden whitespace handling so scene specs with inline comments and newlines can be parsed
- expand nominal and pragmatic operators to cover unicode glyphs, unit suffixes, ranges, comparisons, and new fixity symbols
- update tests to exercise parsing the published seed specification and adjust the test runner to discover nested test files

## Testing
- yarn test

------
https://chatgpt.com/codex/tasks/task_e_68f2e31bad98832199e3628d505fd2a6